### PR TITLE
feat: bulk link operations

### DIFF
--- a/apps/backend/src/api/routes/links.ts
+++ b/apps/backend/src/api/routes/links.ts
@@ -12,6 +12,8 @@ export default (app: Router) => {
   route.post("/", LinkAdapter.createLink);
   route.post("/feed", LinkAdapter.getUpdatedFeed);
   route.get("/search", LinkAdapter.searchLinks);
+  route.post("/bulk-delete", LinkAdapter.bulkDeleteLinks);
+  route.patch("/bulk", LinkAdapter.bulkUpdateLinks);
   route.get("/:id?", LinkAdapter.getLinks);
   route.patch("/:id", LinkAdapter.updateLink);
   route.delete("/:id", LinkAdapter.deleteLink);

--- a/apps/backend/src/api/routes/tags.ts
+++ b/apps/backend/src/api/routes/tags.ts
@@ -11,6 +11,9 @@ export default (app: Router) => {
   // GET /tags — all tags for current user with link counts
   route.get("/", TagsAdapter.getAllTags);
 
+  // POST /tags/bulk — apply/remove tags across multiple links
+  route.post("/bulk", TagsAdapter.bulkApplyTags);
+
   // GET /tags/links/:tagName — all links for a given tag (cross-collection)
   route.get("/links/:tagName", TagsAdapter.getLinksByTag);
 

--- a/apps/backend/src/application/adapters/links.adapter.ts
+++ b/apps/backend/src/application/adapters/links.adapter.ts
@@ -65,6 +65,30 @@ export default class LinkAdapter {
     ActionResponse.success(res, deletedId, 200, "Link Deleted");
   });
 
+  static bulkDeleteLinks = asyncHandler(async (req: Request, res: Response) => {
+    const { ids } = req.body;
+    if (!Array.isArray(ids) || ids.length === 0) {
+      ActionResponse.error(res, "ids must be a non-empty array", 400, undefined);
+      return;
+    }
+    const deletedIds = await linkService.bulkDeleteLinks(req.session.user_id!, ids);
+    ActionResponse.success(res, { ids: deletedIds }, 200, "Links deleted");
+  });
+
+  static bulkUpdateLinks = asyncHandler(async (req: Request, res: Response) => {
+    const { ids, data } = req.body;
+    if (!Array.isArray(ids) || ids.length === 0) {
+      ActionResponse.error(res, "ids must be a non-empty array", 400, undefined);
+      return;
+    }
+    if (!data || typeof data !== "object") {
+      ActionResponse.error(res, "data must be an object", 400, undefined);
+      return;
+    }
+    const links = await linkService.bulkUpdateLinks(req.session.user_id!, ids, data);
+    ActionResponse.success(res, links, 200, "Links updated");
+  });
+
   static searchLinks = asyncHandler(async (req: Request, res: Response) => {
     const { q: search_query, collection_id, tag, starred } = req.query;
     if (typeof search_query !== "string" || search_query.length === 0) {

--- a/apps/backend/src/application/adapters/tags.adapter.ts
+++ b/apps/backend/src/application/adapters/tags.adapter.ts
@@ -65,4 +65,32 @@ export default class TagsAdapter {
     await tagsRepo.removeTagFromLink(linkId, tagId);
     ActionResponse.success(res, { linkId, tagId }, 200, "Tag removed");
   });
+
+  static bulkApplyTags = asyncHandler(async (req: Request, res: Response) => {
+    const ownerId = req.session.user_id!;
+    const { link_ids, add = [], remove = [] } = req.body as {
+      link_ids: string[];
+      add?: string[];
+      remove?: string[];
+    };
+    if (!Array.isArray(link_ids) || link_ids.length === 0) {
+      ActionResponse.error(res, "link_ids must be a non-empty array", 400, undefined);
+      return;
+    }
+    const normalize = (name: string) =>
+      name.trim().toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "").slice(0, 40);
+
+    const toAdd = add.map(normalize).filter(Boolean);
+    const toRemove = remove.map(normalize).filter(Boolean);
+
+    // Get tag ids for removal
+    await Promise.all(
+      link_ids.flatMap((linkId) => [
+        toAdd.length > 0 ? tagsRepo.upsertTagsForLink(linkId, ownerId, toAdd, true) : Promise.resolve([]),
+        toRemove.length > 0 ? tagsRepo.removeTagNamesFromLink(linkId, ownerId, toRemove) : Promise.resolve(),
+      ]),
+    );
+
+    ActionResponse.success(res, { link_ids, added: toAdd, removed: toRemove }, 200, "Tags updated");
+  });
 }

--- a/apps/backend/src/application/repositories/links.repository.interface.ts
+++ b/apps/backend/src/application/repositories/links.repository.interface.ts
@@ -29,4 +29,6 @@ export interface ILinkRepository {
   deleteLinksByParentIds(parent_ids: string[], owner_id: string): Promise<void>;
   getLinksByParentId(parent_id: string): Promise<Link[]>;
   getLinksByParentIds(parent_ids: string[]): Promise<Link[]>;
+  bulkDeleteLinks(link_ids: string[], owner_id: string): Promise<string[]>;
+  bulkUpdateLinks(link_ids: string[], owner_id: string, data: Partial<LinkUpdate>): Promise<Link[]>;
 }

--- a/apps/backend/src/application/services/links.interface.ts
+++ b/apps/backend/src/application/services/links.interface.ts
@@ -25,4 +25,6 @@ export default interface ILinksService {
   getStarredLinks(owner_id: string): Promise<Link[] | undefined>;
   getLinksCount(owner_id: string, parent_id: string): Promise<number>;
   searchLinks(owner_id: string, search_query: string, filters?: SearchFilters): Promise<Link[] | undefined>;
+  bulkDeleteLinks(owner_id: string, link_ids: string[]): Promise<string[]>;
+  bulkUpdateLinks(owner_id: string, link_ids: string[], data: Partial<LinkUpdate>): Promise<Link[]>;
 }

--- a/apps/backend/src/infrastructure/repositories/links.repository.ts
+++ b/apps/backend/src/infrastructure/repositories/links.repository.ts
@@ -111,4 +111,24 @@ export class LinksRepository implements ILinkRepository {
     if (parent_ids.length === 0) return [];
     return db("links").whereIn("parent_id", parent_ids).select("*");
   }
+
+  async bulkDeleteLinks(link_ids: string[], owner_id: string): Promise<string[]> {
+    if (link_ids.length === 0) return [];
+    const rows = await db("links")
+      .whereIn("id", link_ids)
+      .where({ owner_id })
+      .delete()
+      .returning("id");
+    return rows.map((r: { id: string }) => r.id);
+  }
+
+  async bulkUpdateLinks(link_ids: string[], owner_id: string, data: Partial<LinkUpdate>): Promise<Link[]> {
+    if (link_ids.length === 0) return [];
+    const rows = await db("links")
+      .whereIn("id", link_ids)
+      .where({ owner_id })
+      .update(data)
+      .returning("*");
+    return rows;
+  }
 }

--- a/apps/backend/src/infrastructure/repositories/tags.repository.ts
+++ b/apps/backend/src/infrastructure/repositories/tags.repository.ts
@@ -69,6 +69,20 @@ export class TagsRepository {
       .select("tags.*", "link_tags.confirmed", "link_tags.link_id");
   }
 
+  async removeTagNamesFromLink(linkId: string, ownerId: string, tagNames: string[]): Promise<void> {
+    if (tagNames.length === 0) return;
+    const tags = await db("tags")
+      .where("owner_id", ownerId)
+      .whereIn("name", tagNames)
+      .select("id");
+    const tagIds = tags.map((t: { id: string }) => t.id);
+    if (tagIds.length === 0) return;
+    await db("link_tags")
+      .where("link_id", linkId)
+      .whereIn("tag_id", tagIds)
+      .delete();
+  }
+
   async getLinksByTag(
     ownerId: string,
     tagName: string,

--- a/apps/backend/src/infrastructure/services/links.service.ts
+++ b/apps/backend/src/infrastructure/services/links.service.ts
@@ -215,6 +215,15 @@ export default class LinkService implements ILinksService {
     return linksCount;
   }
 
+  async bulkDeleteLinks(owner_id: string, link_ids: string[]): Promise<string[]> {
+    return this.linkRepository.bulkDeleteLinks(link_ids, owner_id);
+  }
+
+  async bulkUpdateLinks(owner_id: string, link_ids: string[], data: Partial<LinkUpdate>): Promise<Link[]> {
+    const rows = await this.linkRepository.bulkUpdateLinks(link_ids, owner_id, data);
+    return rows.map((link) => LinkDTO.fromObject(link).toObject());
+  }
+
   async searchLinks(owner_id: string, search_query: string, filters?: SearchFilters): Promise<Link[] | undefined> {
     const links = await this.linkRepository.getSearchLinks(owner_id, search_query, filters);
     if (!links) return undefined;

--- a/apps/web/src/app/provider.tsx
+++ b/apps/web/src/app/provider.tsx
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { store, persistor } from "@store/store";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ToastProvider } from "@components/ui/toast";
 type GlobalAppProviderProps = {
   children: ReactNode;
 };
@@ -19,7 +20,9 @@ export const GlobalAppProvider = ({ children }: GlobalAppProviderProps) => {
       <Provider store={store}>
         <PersistGate loading={null} persistor={persistor}>
           <QueryClientProvider client={queryClient}>
-            {children}
+            <ToastProvider>
+              {children}
+            </ToastProvider>
             <ReactQueryDevtools initialIsOpen={false} />
           </QueryClientProvider>
         </PersistGate>

--- a/apps/web/src/components/bulk/bulk-action-bar.tsx
+++ b/apps/web/src/components/bulk/bulk-action-bar.tsx
@@ -1,0 +1,156 @@
+import { createPortal } from "react-dom";
+import { cn } from "@lib/tailwind-utils";
+import {
+  PiStar,
+  PiStarFill,
+  PiTrash,
+  PiCopy,
+  PiX,
+  PiDotsThree,
+} from "react-icons/pi";
+import { TbFolderShare } from "react-icons/tb";
+import { HiOutlineTag } from "react-icons/hi";
+import type { Link } from "@onelink/entities/models";
+
+interface BulkActionBarProps {
+  selectedIds: string[];
+  allLinks: Link[];
+  onClear: () => void;
+  onDelete: () => void;
+  onStar: () => void;
+  onUnstar: () => void;
+  onMove: () => void;
+  onTag: () => void;
+  onCopyUrls: () => void;
+  isDeleting?: boolean;
+  isUpdating?: boolean;
+}
+
+export default function BulkActionBar({
+  selectedIds,
+  allLinks,
+  onClear,
+  onDelete,
+  onStar,
+  onUnstar,
+  onMove,
+  onTag,
+  onCopyUrls,
+  isDeleting,
+  isUpdating,
+}: BulkActionBarProps) {
+  const count = selectedIds.length;
+  if (count === 0) return null;
+
+  const selectedLinks = allLinks.filter((l) => selectedIds.includes(l.id));
+  const allStarred = selectedLinks.length > 0 && selectedLinks.every((l) => l.is_starred);
+
+  return createPortal(
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9998] animate-in fade-in slide-in-from-bottom-4 duration-200">
+      <div className="flex items-center gap-1 bg-[#111] border border-white/20 rounded-xl shadow-2xl px-2 py-1.5 min-w-[420px] max-w-[90vw]">
+        {/* Clear + count */}
+        <button
+          onClick={onClear}
+          title="Clear selection (Esc)"
+          className="flex items-center justify-center w-7 h-7 rounded-lg text-white/50 hover:text-white hover:bg-white/10 transition-colors cursor-pointer shrink-0"
+        >
+          <PiX className="text-sm" />
+        </button>
+
+        <span className="text-xs font-semibold text-white px-1.5 shrink-0">
+          {count} selected
+        </span>
+
+        <div className="w-px h-5 bg-white/10 mx-1 shrink-0" />
+
+        {/* Star / Unstar */}
+        <ActionButton
+          onClick={allStarred ? onUnstar : onStar}
+          title={allStarred ? "Unstar all" : "Star all"}
+          disabled={isUpdating}
+          icon={
+            allStarred
+              ? <PiStarFill className="text-yellow-400" />
+              : <PiStar />
+          }
+          label={allStarred ? "Unstar" : "Star"}
+        />
+
+        {/* Tag */}
+        <ActionButton
+          onClick={onTag}
+          title="Tag selected"
+          disabled={isUpdating}
+          icon={<HiOutlineTag />}
+          label="Tag"
+        />
+
+        {/* Move */}
+        <ActionButton
+          onClick={onMove}
+          title="Move to collection"
+          disabled={isUpdating}
+          icon={<TbFolderShare />}
+          label="Move"
+        />
+
+        {/* Copy URLs */}
+        <ActionButton
+          onClick={onCopyUrls}
+          title="Copy URLs"
+          icon={<PiCopy />}
+          label="Copy URLs"
+        />
+
+        <div className="flex-1" />
+
+        {/* Delete — visually separated */}
+        <div className="w-px h-5 bg-white/10 mx-1 shrink-0" />
+        <button
+          onClick={onDelete}
+          title="Delete selected"
+          disabled={isDeleting}
+          className={cn(
+            "flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors cursor-pointer",
+            "text-red-400 hover:text-red-300 hover:bg-red-500/10",
+            isDeleting && "opacity-50 cursor-not-allowed",
+          )}
+        >
+          <PiTrash className="text-sm" />
+          <span className="hidden sm:inline">Delete</span>
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function ActionButton({
+  onClick,
+  title,
+  icon,
+  label,
+  disabled,
+}: {
+  onClick: () => void;
+  title: string;
+  icon: React.ReactNode;
+  label: string;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      disabled={disabled}
+      className={cn(
+        "flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors cursor-pointer",
+        "text-white/60 hover:text-white hover:bg-white/10",
+        disabled && "opacity-50 cursor-not-allowed",
+      )}
+    >
+      <span className="text-sm">{icon}</span>
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/bulk/bulk-move-modal.tsx
+++ b/apps/web/src/components/bulk/bulk-move-modal.tsx
@@ -1,0 +1,277 @@
+import { useState, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { useAppSelector } from "@store/store";
+import { getAllCollections } from "@store/slices/collections-slice";
+import type { Collection } from "@onelink/entities/models";
+import { cn } from "@lib/tailwind-utils";
+import {
+  BiSolidFolder,
+  BiFolder,
+  BiSearch,
+  BiHome,
+  BiChevronRight,
+} from "react-icons/bi";
+import { RiLoaderLine } from "react-icons/ri";
+
+type Props = {
+  count: number;
+  onClose: () => void;
+  onMove: (targetId: string | null) => void;
+  isPending?: boolean;
+};
+
+type ViewMode = "browse" | "search";
+
+export function BulkMoveModal({ count, onClose, onMove, isPending }: Props) {
+  const allCollections = useAppSelector(getAllCollections);
+
+  const [viewMode, setViewMode] = useState<ViewMode>("browse");
+  const [currentParentId, setCurrentParentId] = useState<string | null>(null);
+  const [breadcrumbs, setBreadcrumbs] = useState<Collection[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null | "root">("root");
+
+  const visibleCollections = useMemo(
+    () => allCollections.filter((c) => c.parent_id === currentParentId),
+    [allCollections, currentParentId],
+  );
+
+  const searchResults = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return allCollections.filter((c) => c.name.toLowerCase().includes(q));
+  }, [allCollections, searchQuery]);
+
+  const navigate = (collection: Collection) => {
+    setBreadcrumbs((prev) => [...prev, collection]);
+    setCurrentParentId(collection.id);
+  };
+
+  const navigateToBreadcrumb = (index: number) => {
+    if (index === -1) {
+      setBreadcrumbs([]);
+      setCurrentParentId(null);
+    } else {
+      const next = breadcrumbs.slice(0, index + 1);
+      setBreadcrumbs(next);
+      setCurrentParentId(next[next.length - 1].id);
+    }
+  };
+
+  const handleMove = () => {
+    const targetId = selectedId === "root" ? null : selectedId;
+    onMove(targetId);
+  };
+
+  const currentSelectionName =
+    selectedId === "root"
+      ? "Home"
+      : allCollections.find((c) => c.id === selectedId)?.name ?? "Unknown";
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center"
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative z-[10000] w-full max-w-sm mx-4 bg-theme_primary_black border-2 border-white/20 rounded-md overflow-hidden flex flex-col h-[70vh] max-h-[520px] min-h-[320px]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3.5 border-b border-white/10 shrink-0">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-white">Move {count} links to…</h2>
+            <p className="text-[0.65rem] text-white/40 mt-0.5">
+              Select a destination collection
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/40 hover:text-white transition-colors ml-3 shrink-0 text-lg leading-none"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="px-3 py-2.5 border-b border-white/10 shrink-0">
+          <div className="flex items-center gap-2 bg-white/5 border border-white/10 rounded-md px-2.5 py-1.5">
+            <BiSearch className="text-white/30 shrink-0 text-sm" />
+            <input
+              type="text"
+              placeholder="Search collections..."
+              value={searchQuery}
+              autoFocus
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setViewMode(e.target.value ? "search" : "browse");
+              }}
+              className="flex-1 bg-transparent text-xs text-white placeholder:text-white/30 focus:outline-none"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => { setSearchQuery(""); setViewMode("browse"); }}
+                className="text-white/30 hover:text-white transition-colors text-sm leading-none"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Breadcrumbs */}
+        {viewMode === "browse" && (
+          <div className="flex items-center gap-1 px-3 py-1.5 border-b border-white/8 shrink-0 overflow-x-auto">
+            <button
+              onClick={() => navigateToBreadcrumb(-1)}
+              className={cn(
+                "flex items-center gap-1 text-[0.65rem] shrink-0 transition-colors",
+                currentParentId === null ? "text-white font-medium" : "text-white/40 hover:text-white",
+              )}
+            >
+              <BiHome className="text-[0.7rem]" /> Home
+            </button>
+            {breadcrumbs.map((crumb, i) => (
+              <div key={crumb.id} className="flex items-center gap-1 shrink-0">
+                <BiChevronRight className="text-white/25 text-[0.65rem]" />
+                <button
+                  onClick={() => navigateToBreadcrumb(i)}
+                  className={cn(
+                    "text-[0.65rem] transition-colors max-w-[80px] truncate",
+                    i === breadcrumbs.length - 1 ? "text-white font-medium" : "text-white/40 hover:text-white",
+                  )}
+                >
+                  {crumb.name}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* List */}
+        <div className="flex-1 overflow-y-auto py-1 min-h-0">
+          {viewMode === "browse" ? (
+            <>
+              <CollectionOption
+                id={currentParentId === null ? "root" : currentParentId}
+                name={currentParentId === null ? "Home" : breadcrumbs[breadcrumbs.length - 1]?.name ?? "Here"}
+                isHome={currentParentId === null}
+                isSelected={currentParentId === null ? selectedId === "root" : selectedId === currentParentId}
+                hasChildren={false}
+                onClick={() => setSelectedId(currentParentId === null ? "root" : currentParentId)}
+                isThisLevel
+              />
+              {visibleCollections.length === 0 ? (
+                <p className="text-xs text-white/25 px-4 py-3">No sub-collections here</p>
+              ) : (
+                visibleCollections.map((col) => {
+                  const hasChildren = allCollections.some((c) => c.parent_id === col.id);
+                  return (
+                    <CollectionOption
+                      key={col.id}
+                      id={col.id}
+                      name={col.name}
+                      isHome={false}
+                      isSelected={selectedId === col.id}
+                      hasChildren={hasChildren}
+                      onClick={() => setSelectedId(col.id)}
+                      onNavigate={() => navigate(col)}
+                    />
+                  );
+                })
+              )}
+            </>
+          ) : searchResults.length === 0 ? (
+            <p className="text-xs text-white/25 px-4 py-4 text-center">No collections found</p>
+          ) : (
+            searchResults.map((col) => {
+              const hasChildren = allCollections.some((c) => c.parent_id === col.id);
+              return (
+                <CollectionOption
+                  key={col.id}
+                  id={col.id}
+                  name={col.name}
+                  isHome={false}
+                  isSelected={selectedId === col.id}
+                  hasChildren={hasChildren}
+                  onClick={() => setSelectedId(col.id)}
+                />
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-3 py-3 border-t border-white/10 shrink-0 flex items-center justify-between gap-3">
+          <div className="min-w-0 flex items-center gap-1.5">
+            <BiSolidFolder className="text-white/30 shrink-0 text-xs" />
+            <span className="text-xs text-white/50 truncate">
+              Moving to: <span className="text-white font-medium">{currentSelectionName}</span>
+            </span>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button onClick={onClose} className="px-3 py-1.5 text-xs text-white/50 hover:text-white transition-colors">
+              Cancel
+            </button>
+            <button
+              onClick={handleMove}
+              disabled={isPending}
+              className="px-3 py-1.5 rounded-md text-xs font-medium bg-white text-black hover:bg-white/90 cursor-pointer flex items-center gap-1.5 disabled:opacity-60 disabled:cursor-not-allowed transition-all"
+            >
+              {isPending && <RiLoaderLine className="animate-spin text-xs" />}
+              Move
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+type CollectionOptionProps = {
+  id: string;
+  name: string;
+  isHome: boolean;
+  isSelected: boolean;
+  hasChildren: boolean;
+  isThisLevel?: boolean;
+  onClick: () => void;
+  onNavigate?: () => void;
+};
+
+function CollectionOption({ id, name, isHome, isSelected, hasChildren, isThisLevel = false, onClick, onNavigate }: CollectionOptionProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors group/opt",
+        isSelected ? "bg-white/10" : "hover:bg-white/5",
+      )}
+      onClick={onClick}
+    >
+      <div className={cn(
+        "w-3.5 h-3.5 rounded-full border shrink-0 flex items-center justify-center transition-all",
+        isSelected ? "border-white bg-white" : "border-white/20 group-hover/opt:border-white/40",
+      )}>
+        {isSelected && <div className="w-1.5 h-1.5 rounded-full bg-black" />}
+      </div>
+      {isHome ? <BiHome className="text-white/50 text-sm shrink-0" /> : <BiFolder className="text-white/50 text-sm shrink-0" />}
+      <div className="flex-1 min-w-0">
+        <span className={cn("text-xs truncate", isSelected ? "text-white font-medium" : "text-white/70")}>
+          {name}
+          {isThisLevel && !isHome && <span className="ml-1.5 text-[0.6rem] text-white/30">(this level)</span>}
+        </span>
+      </div>
+      {hasChildren && onNavigate && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onNavigate(); }}
+          className="shrink-0 text-white/20 hover:text-white transition-colors p-0.5 rounded hover:bg-white/10"
+        >
+          <BiChevronRight className="text-sm" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/bulk/bulk-tag-popover.tsx
+++ b/apps/web/src/components/bulk/bulk-tag-popover.tsx
@@ -1,0 +1,195 @@
+import { useState, useMemo } from "react";
+import { createPortal } from "react-dom";
+import type { Link } from "@onelink/entities/models";
+import { cn } from "@lib/tailwind-utils";
+import { BiSearch } from "react-icons/bi";
+import { RiLoaderLine } from "react-icons/ri";
+
+type TagState = "all" | "some" | "none";
+
+interface TagEntry {
+  name: string;
+  state: TagState;
+}
+
+interface BulkTagPopoverProps {
+  selectedIds: string[];
+  allLinks: Link[];
+  onClose: () => void;
+  onApplyTags: (toAdd: string[], toRemove: string[]) => void;
+  isPending?: boolean;
+}
+
+export function BulkTagPopover({
+  selectedIds,
+  allLinks,
+  onClose,
+  onApplyTags,
+  isPending,
+}: BulkTagPopoverProps) {
+  const selectedLinks = allLinks.filter((l) => selectedIds.includes(l.id));
+
+  // Build map: tagName → how many selected links have it
+  const tagCountMap = useMemo(() => {
+    const map = new Map<string, number>();
+    selectedLinks.forEach((link) => {
+      link.tags?.forEach((t) => {
+        if (t.confirmed) {
+          map.set(t.name, (map.get(t.name) ?? 0) + 1);
+        }
+      });
+    });
+    return map;
+  }, [selectedLinks]);
+
+  // Also collect all available tags from the full link list for suggestions
+  const allAvailableTags = useMemo(() => {
+    const set = new Set<string>();
+    allLinks.forEach((l) => l.tags?.forEach((t) => { if (t.confirmed) set.add(t.name); }));
+    return Array.from(set).sort();
+  }, [allLinks]);
+
+  const initialTags: TagEntry[] = useMemo(() => {
+    return allAvailableTags.map((name) => {
+      const count = tagCountMap.get(name) ?? 0;
+      const state: TagState =
+        count === selectedLinks.length ? "all" :
+        count > 0 ? "some" : "none";
+      return { name, state };
+    });
+  }, [allAvailableTags, tagCountMap, selectedLinks.length]);
+
+  // Local override state: maps tag name → desired final state (null = no change from initial)
+  const [overrides, setOverrides] = useState<Map<string, "all" | "none">>(new Map());
+  const [search, setSearch] = useState("");
+  const [newTag, setNewTag] = useState("");
+
+  const resolvedTags: TagEntry[] = useMemo(() => {
+    return initialTags.map((t) => {
+      const override = overrides.get(t.name);
+      return override ? { name: t.name, state: override } : t;
+    });
+  }, [initialTags, overrides]);
+
+  const filteredTags = useMemo(() => {
+    const q = search.toLowerCase();
+    return resolvedTags.filter((t) => t.name.toLowerCase().includes(q));
+  }, [resolvedTags, search]);
+
+  const toggle = (name: string, currentState: TagState) => {
+    // none / some → all; all → none
+    const next: "all" | "none" = currentState === "all" ? "none" : "all";
+    setOverrides((prev) => new Map(prev).set(name, next));
+  };
+
+  const handleApply = () => {
+    const toAdd: string[] = [];
+    const toRemove: string[] = [];
+    resolvedTags.forEach((t) => {
+      const initial = initialTags.find((i) => i.name === t.name)!;
+      if (t.state === "all" && initial.state !== "all") toAdd.push(t.name);
+      if (t.state === "none" && initial.state !== "none") toRemove.push(t.name);
+    });
+    // New tag
+    const trimmed = newTag.trim();
+    if (trimmed && !toAdd.includes(trimmed)) toAdd.push(trimmed);
+    onApplyTags(toAdd, toRemove);
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center"
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="relative z-[10000] w-full max-w-xs mx-4 bg-[#111] border border-white/20 rounded-md overflow-hidden flex flex-col max-h-[480px]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-white/10 shrink-0">
+          <h2 className="text-sm font-semibold text-white">Tag {selectedIds.length} links</h2>
+          <button onClick={onClose} className="text-white/40 hover:text-white text-lg leading-none">✕</button>
+        </div>
+
+        {/* Search */}
+        <div className="px-3 py-2 border-b border-white/10 shrink-0">
+          <div className="flex items-center gap-2 bg-white/5 border border-white/10 rounded-md px-2.5 py-1.5">
+            <BiSearch className="text-white/30 text-sm shrink-0" />
+            <input
+              type="text"
+              placeholder="Search tags..."
+              value={search}
+              autoFocus
+              onChange={(e) => setSearch(e.target.value)}
+              className="flex-1 bg-transparent text-xs text-white placeholder:text-white/30 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        {/* Tag list */}
+        <div className="flex-1 overflow-y-auto py-1 min-h-0">
+          {filteredTags.length === 0 ? (
+            <p className="text-xs text-white/25 px-4 py-3 text-center">No tags found</p>
+          ) : (
+            filteredTags.map((tag) => (
+              <button
+                key={tag.name}
+                onClick={() => toggle(tag.name, tag.state)}
+                className={cn(
+                  "w-full flex items-center gap-3 px-3 py-2 transition-colors cursor-pointer hover:bg-white/5",
+                )}
+              >
+                {/* Checkbox with partial state */}
+                <div className={cn(
+                  "w-3.5 h-3.5 rounded border shrink-0 flex items-center justify-center transition-all",
+                  tag.state === "all" ? "border-primary bg-primary" :
+                  tag.state === "some" ? "border-primary/60 bg-primary/20" :
+                  "border-white/20",
+                )}>
+                  {tag.state === "all" && <span className="text-white text-[0.55rem] font-bold leading-none">✓</span>}
+                  {tag.state === "some" && <span className="text-primary text-[0.55rem] font-bold leading-none">—</span>}
+                </div>
+                <span className={cn(
+                  "text-xs truncate",
+                  tag.state === "all" ? "text-white font-medium" : "text-white/60",
+                )}>
+                  {tag.name}
+                </span>
+                {tag.state === "some" && (
+                  <span className="ml-auto text-[0.6rem] text-white/25 shrink-0">partial</span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* New tag input */}
+        <div className="px-3 py-2 border-t border-white/10 shrink-0">
+          <input
+            type="text"
+            placeholder="Create new tag..."
+            value={newTag}
+            onChange={(e) => setNewTag(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleApply()}
+            className="w-full bg-white/5 border border-white/10 rounded-md px-2.5 py-1.5 text-xs text-white placeholder:text-white/30 focus:outline-none focus:border-white/30"
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="px-3 py-2.5 border-t border-white/10 shrink-0 flex justify-end gap-2">
+          <button onClick={onClose} className="px-3 py-1.5 text-xs text-white/50 hover:text-white transition-colors">
+            Cancel
+          </button>
+          <button
+            onClick={handleApply}
+            disabled={isPending}
+            className="px-3 py-1.5 rounded-md text-xs font-medium bg-white text-black hover:bg-white/90 cursor-pointer flex items-center gap-1.5 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {isPending && <RiLoaderLine className="animate-spin text-xs" />}
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/cards/link-card.tsx
+++ b/apps/web/src/components/cards/link-card.tsx
@@ -15,14 +15,18 @@ interface LinkCardProps {
   height?: string;
   index?: number;
   showOgImage?: boolean;
+  isSelected?: boolean;
+  onSelect?: (e: React.MouseEvent) => void;
 }
 
 interface LinkCardActionsProps {
   data: Link;
   onMoveClick: () => void;
+  selectionMode?: boolean;
 }
 
-function LinkCardActions({ data, onMoveClick }: LinkCardActionsProps) {
+function LinkCardActions({ data, onMoveClick, selectionMode }: LinkCardActionsProps) {
+  if (selectionMode) return null;
   return (
     <div className="hidden group-hover:flex items-center gap-1.5">
       <button
@@ -53,45 +57,69 @@ function LinkCardWithoutImage({
   data,
   index,
   onMoveClick,
+  isSelected,
+  onSelect,
 }: {
   data: Link;
   index?: number;
   onMoveClick: () => void;
+  isSelected?: boolean;
+  onSelect?: (e: React.MouseEvent) => void;
 }) {
+  const selectionMode = !!onSelect;
   return (
     <GlowCard
-      className="group w-full rounded-none before:rounded-md after:rounded-md before:w-full before:h-full border-[1px] border-white/20 text-white cursor-pointer"
+      className={`group w-full rounded-none before:rounded-md after:rounded-md before:w-full before:h-full border-[1px] text-white cursor-pointer transition-colors ${isSelected ? "border-primary/60 bg-primary/5" : "border-white/20"}`}
       style={{ minHeight: "11rem" }}
       containerClassName="flex-col gap-2 rounded-md p-3 justify-between items-start"
-      onDoubleClick={() => openExternalLink(data.link)}
+      onDoubleClick={() => !selectionMode && openExternalLink(data.link)}
+      onClick={onSelect}
     >
       <div className="w-full flex flex-col gap-4">
         <div className="w-full flex justify-between items-center">
-          {index !== undefined && (
-            <span className="text-[0.6rem] text-theme_secondary_white/40 font-mono select-none">
-              #{String(index + 1).padStart(3, "0")}
-            </span>
-          )}
           <div className="flex items-center gap-1.5">
+            {/* Checkbox — visible on hover or when in selection mode */}
             <span
-              className={
-                !data.is_starred
-                  ? "opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-                  : ""
-              }
+              className={`${isSelected || selectionMode ? "opacity-100" : "opacity-0 group-hover:opacity-100"} transition-opacity duration-150`}
+              onClick={(e) => { e.stopPropagation(); onSelect?.(e); }}
             >
-              <StarButton starred={data.is_starred ?? false} id={data.id} subtle />
+              <input
+                type="checkbox"
+                checked={!!isSelected}
+                onChange={() => {}}
+                className="w-3.5 h-3.5 accent-primary cursor-pointer"
+              />
             </span>
-            <span
-              className={
-                !data.subscribed
-                  ? "opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-                  : ""
-              }
-            >
-              <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
-            </span>
-            <LinkCardActions data={data} onMoveClick={onMoveClick} />
+            {index !== undefined && !selectionMode && (
+              <span className="text-[0.6rem] text-theme_secondary_white/40 font-mono select-none">
+                #{String(index + 1).padStart(3, "0")}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5">
+            {!selectionMode && (
+              <>
+                <span
+                  className={
+                    !data.is_starred
+                      ? "opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                      : ""
+                  }
+                >
+                  <StarButton starred={data.is_starred ?? false} id={data.id} subtle />
+                </span>
+                <span
+                  className={
+                    !data.subscribed
+                      ? "opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                      : ""
+                  }
+                >
+                  <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
+                </span>
+              </>
+            )}
+            <LinkCardActions data={data} onMoveClick={onMoveClick} selectionMode={selectionMode} />
           </div>
         </div>
         <span>
@@ -114,17 +142,23 @@ function LinkCardWithImage({
   data,
   height,
   onMoveClick,
+  isSelected,
+  onSelect,
 }: {
   data: Link;
   height: string;
   onMoveClick: () => void;
+  isSelected?: boolean;
+  onSelect?: (e: React.MouseEvent) => void;
 }) {
+  const selectionMode = !!onSelect;
   return (
     <GlowCard
-      className="w-full rounded-none before:rounded-md after:rounded-md before:w-full before:h-60 border-[1px] border-white/20 text-white cursor-pointer"
+      className={`w-full rounded-none before:rounded-md after:rounded-md before:w-full before:h-60 border-[1px] text-white cursor-pointer transition-colors ${isSelected ? "border-primary/60 bg-primary/5" : "border-white/20"}`}
       style={{ height: `calc(${height} + 2.5rem)` }}
       containerClassName="flex-col gap-2 rounded-md p-2 justify-between items-start"
-      onDoubleClick={() => openExternalLink(data.link)}
+      onDoubleClick={() => !selectionMode && openExternalLink(data.link)}
+      onClick={onSelect}
     >
       <div className="w-full flex flex-col gap-2">
         <section className="w-full aspect-[1.91] rounded-md overflow-hidden bg-theme_secondary_black relative flex items-center justify-center select-none">
@@ -133,7 +167,22 @@ function LinkCardWithImage({
             {formatLink(data.link)}
           </span>
           <section className="absolute top-2 right-2 w-full flex items-center gap-1 justify-end">
-            <StarButton starred={data.is_starred ?? false} id={data.id} />
+            {/* Checkbox in selection mode, star otherwise */}
+            {selectionMode ? (
+              <span
+                className={`${isSelected ? "opacity-100" : "opacity-0 group-hover:opacity-100"} transition-opacity duration-150`}
+                onClick={(e) => { e.stopPropagation(); onSelect?.(e); }}
+              >
+                <input
+                  type="checkbox"
+                  checked={!!isSelected}
+                  onChange={() => {}}
+                  className="w-3.5 h-3.5 accent-primary cursor-pointer"
+                />
+              </span>
+            ) : (
+              <StarButton starred={data.is_starred ?? false} id={data.id} />
+            )}
           </section>
         </section>
         <span>
@@ -145,36 +194,38 @@ function LinkCardWithImage({
           </p>
         </span>
       </div>
-      <section className="w-full flex justify-between items-center relative">
-        <div className="flex items-center gap-1.5">
-          <DeleteLinkButton id={data.id} />
-          <button
-            className="text-sm cursor-pointer text-theme_secondary_white/40 hover:text-theme_secondary_white transition-colors"
-            title="Move to collection"
-            onClick={(e) => {
-              e.stopPropagation();
-              onMoveClick();
-            }}
-          >
-            <TbFolderShare />
-          </button>
-        </div>
-        <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
-      </section>
+      {!selectionMode && (
+        <section className="w-full flex justify-between items-center relative">
+          <div className="flex items-center gap-1.5">
+            <DeleteLinkButton id={data.id} />
+            <button
+              className="text-sm cursor-pointer text-theme_secondary_white/40 hover:text-theme_secondary_white transition-colors"
+              title="Move to collection"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMoveClick();
+              }}
+            >
+              <TbFolderShare />
+            </button>
+          </div>
+          <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
+        </section>
+      )}
     </GlowCard>
   );
 }
 
-const LinkCard = ({ data, height = "15rem", index, showOgImage = true }: LinkCardProps) => {
+const LinkCard = ({ data, height = "15rem", index, showOgImage = true, isSelected, onSelect }: LinkCardProps) => {
   const [moveOpen, setMoveOpen] = useState(false);
   const hasImage = showOgImage && data.open_graph && data.open_graph.length > 0;
 
   return (
     <>
       {hasImage ? (
-        <LinkCardWithImage data={data} height={height} onMoveClick={() => setMoveOpen(true)} />
+        <LinkCardWithImage data={data} height={height} onMoveClick={() => setMoveOpen(true)} isSelected={isSelected} onSelect={onSelect} />
       ) : (
-        <LinkCardWithoutImage data={data} index={index} onMoveClick={() => setMoveOpen(true)} />
+        <LinkCardWithoutImage data={data} index={index} onMoveClick={() => setMoveOpen(true)} isSelected={isSelected} onSelect={onSelect} />
       )}
       {moveOpen && (
         <MoveToCollectionModal link={data} onClose={() => setMoveOpen(false)} />

--- a/apps/web/src/components/cards/link-compact-item.tsx
+++ b/apps/web/src/components/cards/link-compact-item.tsx
@@ -11,19 +11,37 @@ import { TbFolderShare } from "react-icons/tb";
 
 interface LinkCompactItemProps {
   data: Link;
+  isSelected?: boolean;
+  onSelect?: (e: React.MouseEvent) => void;
 }
 
-export default function LinkCompactItem({ data }: LinkCompactItemProps) {
+export default function LinkCompactItem({ data, isSelected, onSelect }: LinkCompactItemProps) {
   const domain = extractDomain(data.link);
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
   const [moveOpen, setMoveOpen] = useState(false);
+  const selectionMode = !!onSelect;
 
   return (
     <>
     <div
-      className="w-full flex items-center gap-3 px-3 py-2 border-b border-white/8 hover:bg-white/4 transition-colors duration-150 group cursor-pointer"
-      onDoubleClick={() => window.open(data.link, "_blank")}
+      className={`w-full flex items-center gap-3 px-3 py-2 border-b border-white/8 transition-colors duration-150 group cursor-pointer ${isSelected ? "bg-primary/8 border-l-2 border-l-primary" : "hover:bg-white/4"}`}
+      onDoubleClick={() => !selectionMode && window.open(data.link, "_blank")}
+      onClick={onSelect}
     >
+      {/* Checkbox in selection mode */}
+      {selectionMode && (
+        <span
+          className={`shrink-0 ${isSelected ? "opacity-100" : "opacity-0 group-hover:opacity-100"} transition-opacity duration-150`}
+          onClick={(e) => { e.stopPropagation(); onSelect?.(e); }}
+        >
+          <input
+            type="checkbox"
+            checked={!!isSelected}
+            onChange={() => {}}
+            className="w-3.5 h-3.5 accent-primary cursor-pointer"
+          />
+        </span>
+      )}
       {/* Favicon */}
       <img
         src={faviconUrl}
@@ -60,22 +78,24 @@ export default function LinkCompactItem({ data }: LinkCompactItemProps) {
         </span>
       )}
 
-      {/* Actions */}
-      <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-        <StarButton starred={data.is_starred ?? false} id={data.id} subtle />
-        <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
-        <button
-          className="text-sm cursor-pointer text-theme_secondary_white/40 hover:text-theme_secondary_white transition-colors"
-          title="Move to collection"
-          onClick={(e) => {
-            e.stopPropagation();
-            setMoveOpen(true);
-          }}
-        >
-          <TbFolderShare />
-        </button>
-        <DeleteLinkButton id={data.id} subtle />
-      </div>
+      {/* Actions — hidden in selection mode */}
+      {!selectionMode && (
+        <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+          <StarButton starred={data.is_starred ?? false} id={data.id} subtle />
+          <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
+          <button
+            className="text-sm cursor-pointer text-theme_secondary_white/40 hover:text-theme_secondary_white transition-colors"
+            title="Move to collection"
+            onClick={(e) => {
+              e.stopPropagation();
+              setMoveOpen(true);
+            }}
+          >
+            <TbFolderShare />
+          </button>
+          <DeleteLinkButton id={data.id} subtle />
+        </div>
+      )}
     </div>
     {moveOpen && (
       <MoveToCollectionModal link={data} onClose={() => setMoveOpen(false)} />

--- a/apps/web/src/components/cards/link-list-item.tsx
+++ b/apps/web/src/components/cards/link-list-item.tsx
@@ -10,17 +10,35 @@ import { TbFolderShare } from "react-icons/tb";
 
 interface LinkListItemProps {
   data: Link;
+  isSelected?: boolean;
+  onSelect?: (e: React.MouseEvent) => void;
 }
 
-export default function LinkListItem({ data }: LinkListItemProps) {
+export default function LinkListItem({ data, isSelected, onSelect }: LinkListItemProps) {
   const [moveOpen, setMoveOpen] = useState(false);
+  const selectionMode = !!onSelect;
 
   return (
     <>
     <div
-      className="w-full flex items-center gap-3 px-3 py-2.5 border-b border-white/8 hover:bg-white/4 transition-colors duration-150 group"
-      onDoubleClick={() => window.open(data.link, "_blank")}
+      className={`w-full flex items-center gap-3 px-3 py-2.5 border-b border-white/8 transition-colors duration-150 group cursor-pointer ${isSelected ? "bg-primary/8 border-l-2 border-l-primary" : "hover:bg-white/4"}`}
+      onDoubleClick={() => !selectionMode && window.open(data.link, "_blank")}
+      onClick={onSelect}
     >
+      {/* Checkbox in selection mode */}
+      {selectionMode && (
+        <span
+          className={`shrink-0 ${isSelected ? "opacity-100" : "opacity-0 group-hover:opacity-100"} transition-opacity duration-150`}
+          onClick={(e) => { e.stopPropagation(); onSelect?.(e); }}
+        >
+          <input
+            type="checkbox"
+            checked={!!isSelected}
+            onChange={() => {}}
+            className="w-3.5 h-3.5 accent-primary cursor-pointer"
+          />
+        </span>
+      )}
       {/* OG image thumbnail */}
       <div className="shrink-0 w-20 h-12 rounded-md overflow-hidden bg-white/5 border border-white/10 flex items-center justify-center">
         {data.open_graph && data.open_graph.length > 0 ? (
@@ -64,22 +82,24 @@ export default function LinkListItem({ data }: LinkListItemProps) {
         )}
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-1.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-        <StarButton starred={data.is_starred ?? false} id={data.id} subtle />
-        <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
-        <button
-          className="text-sm cursor-pointer text-theme_secondary_white/40 hover:text-theme_secondary_white transition-colors"
-          title="Move to collection"
-          onClick={(e) => {
-            e.stopPropagation();
-            setMoveOpen(true);
-          }}
-        >
-          <TbFolderShare />
-        </button>
-        <DeleteLinkButton id={data.id} subtle />
-      </div>
+      {/* Actions — hidden in selection mode */}
+      {!selectionMode && (
+        <div className="flex items-center gap-1.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+          <StarButton starred={data.is_starred ?? false} id={data.id} subtle />
+          <SubscribeButton subscribed={data.subscribed ?? false} id={data.id} subtle />
+          <button
+            className="text-sm cursor-pointer text-theme_secondary_white/40 hover:text-theme_secondary_white transition-colors"
+            title="Move to collection"
+            onClick={(e) => {
+              e.stopPropagation();
+              setMoveOpen(true);
+            }}
+          >
+            <TbFolderShare />
+          </button>
+          <DeleteLinkButton id={data.id} subtle />
+        </div>
+      )}
     </div>
     {moveOpen && (
       <MoveToCollectionModal link={data} onClose={() => setMoveOpen(false)} />

--- a/apps/web/src/components/toolbar/view-toolbar.tsx
+++ b/apps/web/src/components/toolbar/view-toolbar.tsx
@@ -12,6 +12,7 @@ import {
   PiArrowsDownUp,
   PiFunnel,
   PiGlobe,
+  PiCheckSquare,
 } from "react-icons/pi";
 import { HiOutlineTag } from "react-icons/hi";
 
@@ -20,6 +21,8 @@ interface ViewToolbarProps {
   onUpdate: (updates: Partial<ViewPreferences>) => void;
   linkCount: number;
   availableTags?: string[];
+  selectionMode?: boolean;
+  onToggleSelectionMode?: () => void;
 }
 
 const VIEW_MODES: { mode: ViewMode; icon: React.ReactNode; label: string }[] = [
@@ -51,6 +54,8 @@ export default function ViewToolbar({
   onUpdate,
   linkCount,
   availableTags = [],
+  selectionMode = false,
+  onToggleSelectionMode,
 }: ViewToolbarProps) {
   const activeSortLabel =
     SORT_OPTIONS.find((o) => o.value === prefs.sortBy)?.label ?? "Sort";
@@ -90,6 +95,23 @@ export default function ViewToolbar({
 
         {/* Right: controls cluster */}
         <div className="flex items-center gap-2 flex-wrap">
+          {/* Select toggle */}
+          {onToggleSelectionMode && (
+            <button
+              title="Select multiple links"
+              onClick={onToggleSelectionMode}
+              className={cn(
+                "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium border transition-all duration-150 cursor-pointer",
+                selectionMode
+                  ? "border-primary/60 bg-primary/10 text-white"
+                  : "border-white/10 bg-white/5 text-white/70 hover:text-white hover:border-white/30",
+              )}
+            >
+              <PiCheckSquare className="text-sm" />
+              <span className="hidden sm:inline">Select</span>
+              {selectionMode && <span className="w-1.5 h-1.5 rounded-full bg-primary" />}
+            </button>
+          )}
           {/* Sort dropdown */}
           <div className="relative group">
             <button className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium border border-white/10 bg-white/5 text-white/70 hover:text-white hover:border-white/30 transition-all duration-150 cursor-pointer">

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,0 +1,67 @@
+import { createContext, useCallback, useContext, useState } from "react";
+import { createPortal } from "react-dom";
+import { PiCheckCircle, PiX } from "react-icons/pi";
+
+interface Toast {
+  id: number;
+  message: string;
+  undoFn?: () => void;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, undoFn?: () => void) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ showToast: () => {} });
+
+let _nextId = 0;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const showToast = useCallback((message: string, undoFn?: () => void) => {
+    const id = ++_nextId;
+    setToasts((prev) => [...prev, { id, message, undoFn }]);
+    setTimeout(() => dismiss(id), 4000);
+  }, [dismiss]);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {createPortal(
+        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[9997] flex flex-col gap-2 pointer-events-none">
+          {toasts.map((t) => (
+            <div
+              key={t.id}
+              className="flex items-center gap-3 bg-[#1a1a1a] border border-white/20 rounded-lg px-4 py-2.5 shadow-xl pointer-events-auto animate-in fade-in slide-in-from-bottom-2 duration-200 min-w-[220px]"
+            >
+              <PiCheckCircle className="text-green-400 text-base shrink-0" />
+              <span className="text-xs text-white flex-1">{t.message}</span>
+              {t.undoFn && (
+                <button
+                  onClick={() => { t.undoFn?.(); dismiss(t.id); }}
+                  className="text-xs text-primary hover:text-primary/80 font-medium transition-colors cursor-pointer"
+                >
+                  Undo
+                </button>
+              )}
+              <button
+                onClick={() => dismiss(t.id)}
+                className="text-white/30 hover:text-white transition-colors cursor-pointer"
+              >
+                <PiX className="text-sm" />
+              </button>
+            </div>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastContext);

--- a/apps/web/src/features/links/bulk-links.ts
+++ b/apps/web/src/features/links/bulk-links.ts
@@ -1,0 +1,74 @@
+import action from "@config/action";
+import { IActionResponse } from "@onelink/action";
+import { Link, LinkUpdate } from "@onelink/entities/models";
+import { useMutation } from "@tanstack/react-query";
+import { useAppDispatch } from "@store/store";
+import { deleteLink, replaceLink } from "@store/slices/links-slice";
+import { deleteFavLink, addOrReplaceFavLink } from "@store/slices/favourite-links-slice";
+import { MutationConfig } from "@lib/react-query";
+
+export const bulkDeleteLinksMutation = ({
+  ids,
+}: {
+  ids: string[];
+}): Promise<IActionResponse<{ ids: string[] }>> => {
+  return action.post("/links/bulk-delete", { ids });
+};
+
+export const bulkUpdateLinksMutation = ({
+  ids,
+  data,
+}: {
+  ids: string[];
+  data: Partial<LinkUpdate>;
+}): Promise<IActionResponse<Link[]>> => {
+  return action.patch("/links/bulk", { ids, data });
+};
+
+type UseBulkDeleteOptions = {
+  mutationConfig?: MutationConfig<typeof bulkDeleteLinksMutation>;
+};
+
+export const useBulkDeleteLinks = ({ mutationConfig }: UseBulkDeleteOptions = {}) => {
+  const dispatch = useAppDispatch();
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      args[0].data.ids.forEach((id) => {
+        dispatch(deleteLink(id));
+        dispatch(deleteFavLink(id));
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: bulkDeleteLinksMutation,
+    mutationKey: ["links:bulk-delete"],
+  });
+};
+
+type UseBulkUpdateOptions = {
+  mutationConfig?: MutationConfig<typeof bulkUpdateLinksMutation>;
+};
+
+export const useBulkUpdateLinks = ({ mutationConfig }: UseBulkUpdateOptions = {}) => {
+  const dispatch = useAppDispatch();
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      args[0].data.forEach((link) => {
+        dispatch(replaceLink(link));
+        if (link.is_starred) {
+          dispatch(addOrReplaceFavLink(link));
+        } else {
+          dispatch(deleteFavLink(link.id));
+        }
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: bulkUpdateLinksMutation,
+    mutationKey: ["links:bulk-update"],
+  });
+};

--- a/apps/web/src/features/tags/bulk-tags.ts
+++ b/apps/web/src/features/tags/bulk-tags.ts
@@ -1,0 +1,34 @@
+import action from "@config/action";
+import { IActionResponse } from "@onelink/action";
+import { useMutation } from "@tanstack/react-query";
+import { MutationConfig } from "@lib/react-query";
+
+interface BulkTagResult {
+  link_ids: string[];
+  added: string[];
+  removed: string[];
+}
+
+export const bulkApplyTagsMutation = ({
+  link_ids,
+  add,
+  remove,
+}: {
+  link_ids: string[];
+  add: string[];
+  remove: string[];
+}): Promise<IActionResponse<BulkTagResult>> => {
+  return action.post("/tags/bulk", { link_ids, add, remove });
+};
+
+type UseBulkApplyTagsOptions = {
+  mutationConfig?: MutationConfig<typeof bulkApplyTagsMutation>;
+};
+
+export const useBulkApplyTags = ({ mutationConfig }: UseBulkApplyTagsOptions = {}) => {
+  return useMutation({
+    ...mutationConfig,
+    mutationFn: bulkApplyTagsMutation,
+    mutationKey: ["tags:bulk-apply"],
+  });
+};

--- a/apps/web/src/sections/links.tsx
+++ b/apps/web/src/sections/links.tsx
@@ -1,6 +1,6 @@
 import { useAppDispatch, useAppSelector } from "@store/store";
 import type { Link } from "@onelink/entities/models";
-import { Fragment, useEffect, useMemo } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useStoredLinks } from "@hooks/links";
 import { useViewPreferences } from "@hooks/view-preferences";
 import LinkCard from "@components/cards/link-card";
@@ -21,6 +21,20 @@ import {
 } from "@lib/utils/link-view";
 import { useSettings } from "@features/settings/get-settings";
 import getFaviconUrl from "@lib/utils/get-favicon-url";
+import {
+  clearSelection,
+  getSelectedIds,
+  selectAll,
+  setRangeSelection,
+  toggleSelection,
+  removeFromSelection,
+} from "@store/slices/selection-slice";
+import BulkActionBar from "@components/bulk/bulk-action-bar";
+import { BulkMoveModal } from "@components/bulk/bulk-move-modal";
+import { BulkTagPopover } from "@components/bulk/bulk-tag-popover";
+import { useBulkDeleteLinks, useBulkUpdateLinks } from "@features/links/bulk-links";
+import { useBulkApplyTags } from "@features/tags/bulk-tags";
+import { useToast } from "@components/ui/toast";
 
 interface LinksContent {
   pathId: string | null;
@@ -39,14 +53,36 @@ interface LinkGroupProps {
   gridClass: string;
   cardHeight: string;
   showOgImage: boolean;
+  selectedIds: string[];
+  onSelectLink: (id: string, e: React.MouseEvent) => void;
+  selectionMode: boolean;
 }
 
-function LinkGroup({ links, viewMode, gridClass, cardHeight, showOgImage }: LinkGroupProps) {
+function LinkGroup({
+  links,
+  viewMode,
+  gridClass,
+  cardHeight,
+  showOgImage,
+  selectedIds,
+  onSelectLink,
+  selectionMode,
+}: LinkGroupProps) {
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
   if (viewMode === "grid") {
     return (
       <div className={`w-full grid ${gridClass}`}>
         {links.map((link, i) => (
-          <LinkCard data={link} key={link.id} height={cardHeight} index={i} showOgImage={showOgImage} />
+          <LinkCard
+            data={link}
+            key={link.id}
+            height={cardHeight}
+            index={i}
+            showOgImage={showOgImage}
+            isSelected={selectedSet.has(link.id)}
+            onSelect={selectionMode ? (e) => onSelectLink(link.id, e) : undefined}
+          />
         ))}
       </div>
     );
@@ -55,7 +91,12 @@ function LinkGroup({ links, viewMode, gridClass, cardHeight, showOgImage }: Link
     return (
       <div className="w-full flex flex-col border border-white/8 rounded-md overflow-hidden">
         {links.map((link) => (
-          <LinkListItem data={link} key={link.id} />
+          <LinkListItem
+            data={link}
+            key={link.id}
+            isSelected={selectedSet.has(link.id)}
+            onSelect={selectionMode ? (e) => onSelectLink(link.id, e) : undefined}
+          />
         ))}
       </div>
     );
@@ -64,7 +105,12 @@ function LinkGroup({ links, viewMode, gridClass, cardHeight, showOgImage }: Link
   return (
     <div className="w-full flex flex-col border border-white/8 rounded-md overflow-hidden">
       {links.map((link) => (
-        <LinkCompactItem data={link} key={link.id} />
+        <LinkCompactItem
+          data={link}
+          key={link.id}
+          isSelected={selectedSet.has(link.id)}
+          onSelect={selectionMode ? (e) => onSelectLink(link.id, e) : undefined}
+        />
       ))}
     </div>
   );
@@ -78,8 +124,27 @@ const LinksContent = ({ pathId }: LinksContent) => {
   const { prefs, updatePrefs } = useViewPreferences(pathId);
   const { data: settingsData } = useSettings();
   const showOgImage = settingsData?.data?.show_og_image ?? true;
+  const { showToast } = useToast();
 
-  // Fetch only when Redux cache is empty for this path — no useState/useEffect cascade.
+  const selectedIds = useAppSelector(getSelectedIds);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [anchorId, setAnchorId] = useState<string | null>(null);
+  const [showMoveModal, setShowMoveModal] = useState(false);
+  const [showTagPopover, setShowTagPopover] = useState(false);
+
+  // Exit selection mode and clear when navigating away
+  useEffect(() => {
+    dispatch(clearSelection());
+    setSelectionMode(false);
+    setAnchorId(null);
+  }, [pathId, dispatch]);
+
+  // Auto-enter selection mode when something gets selected
+  useEffect(() => {
+    if (selectedIds.length > 0) setSelectionMode(true);
+  }, [selectedIds.length]);
+
+  // Fetch only when Redux cache is empty for this path
   const shouldFetch = !links || links.length === 0;
   const linkQuery = useLinks(shouldFetch, pathId);
 
@@ -113,8 +178,166 @@ const LinksContent = ({ pathId }: LinksContent) => {
     return Object.entries(byDomain).sort(([, a], [, b]) => b.length - a.length);
   }, [processedLinks, prefs.groupByDomain]);
 
-  const { gridClass, cardHeight } =
-    DENSITY_CONFIG[prefs.gridDensity] ?? DENSITY_CONFIG[6];
+  const { gridClass, cardHeight } = DENSITY_CONFIG[prefs.gridDensity] ?? DENSITY_CONFIG[6];
+
+  // Flat ordered list for range selection
+  const flatOrderedIds = useMemo(
+    () => processedLinks.map((l) => l.id),
+    [processedLinks],
+  );
+
+  // Bulk mutations
+  const bulkDelete = useBulkDeleteLinks({
+    mutationConfig: {
+      onSuccess: (data) => {
+        const deleted = data.data.ids;
+        dispatch(removeFromSelection(deleted));
+        showToast(`Deleted ${deleted.length} link${deleted.length !== 1 ? "s" : ""}`);
+        if (deleted.length === selectedIds.length) {
+          dispatch(clearSelection());
+          setSelectionMode(false);
+        }
+      },
+    },
+  });
+
+  const bulkUpdate = useBulkUpdateLinks({
+    mutationConfig: {
+      onSuccess: () => {
+        setShowMoveModal(false);
+        setShowTagPopover(false);
+      },
+    },
+  });
+
+  const bulkApplyTags = useBulkApplyTags({
+    mutationConfig: {
+      onSuccess: (data) => {
+        const { added, removed } = data.data;
+        const parts = [];
+        if (added.length > 0) parts.push(`added: ${added.join(", ")}`);
+        if (removed.length > 0) parts.push(`removed: ${removed.join(", ")}`);
+        showToast(`Tags updated — ${parts.join(" · ")}`);
+        setShowTagPopover(false);
+      },
+    },
+  });
+
+  // Selection handler — handles shift-click range and cmd/ctrl toggle
+  const handleSelectLink = useCallback(
+    (id: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (e.shiftKey && anchorId) {
+        const anchorIdx = flatOrderedIds.indexOf(anchorId);
+        const targetIdx = flatOrderedIds.indexOf(id);
+        if (anchorIdx !== -1 && targetIdx !== -1) {
+          const start = Math.min(anchorIdx, targetIdx);
+          const end = Math.max(anchorIdx, targetIdx);
+          const rangeIds = flatOrderedIds.slice(start, end + 1);
+          dispatch(setRangeSelection({ ids: rangeIds, anchorId: id }));
+          setAnchorId(id);
+          return;
+        }
+      }
+      dispatch(toggleSelection(id));
+      setAnchorId(id);
+    },
+    [anchorId, flatOrderedIds, dispatch],
+  );
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+      if ((e.metaKey || e.ctrlKey) && e.key === "a") {
+        e.preventDefault();
+        if (processedLinks.length > 0) {
+          dispatch(selectAll(flatOrderedIds));
+          setSelectionMode(true);
+        }
+        return;
+      }
+
+      if (e.key === "Escape" && selectionMode) {
+        dispatch(clearSelection());
+        setSelectionMode(false);
+        return;
+      }
+
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (selectedIds.length > 0 && !showMoveModal && !showTagPopover) {
+          handleBulkDelete();
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectionMode, selectedIds, flatOrderedIds, showMoveModal, showTagPopover, dispatch]);
+
+  const toggleSelectionMode = () => {
+    if (selectionMode) {
+      dispatch(clearSelection());
+      setSelectionMode(false);
+    } else {
+      setSelectionMode(true);
+    }
+  };
+
+  const handleBulkDelete = () => {
+    if (selectedIds.length === 0) return;
+    const confirmed = window.confirm(
+      `Delete ${selectedIds.length} link${selectedIds.length !== 1 ? "s" : ""}? This cannot be undone.`,
+    );
+    if (confirmed) {
+      bulkDelete.mutate({ ids: selectedIds });
+    }
+  };
+
+  const handleBulkStar = (star: boolean) => {
+    if (selectedIds.length === 0) return;
+    bulkUpdate.mutate(
+      { ids: selectedIds, data: { is_starred: star } },
+      {
+        onSuccess: () => {
+          showToast(`${star ? "Starred" : "Unstarred"} ${selectedIds.length} link${selectedIds.length !== 1 ? "s" : ""}`);
+        },
+      },
+    );
+  };
+
+  const handleBulkMove = (targetId: string | null) => {
+    if (selectedIds.length === 0) return;
+    bulkUpdate.mutate(
+      { ids: selectedIds, data: { parent_id: targetId } },
+      {
+        onSuccess: () => {
+          showToast(`Moved ${selectedIds.length} link${selectedIds.length !== 1 ? "s" : ""}`);
+          dispatch(clearSelection());
+          setSelectionMode(false);
+          setShowMoveModal(false);
+        },
+      },
+    );
+  };
+
+  const handleBulkTag = (toAdd: string[], toRemove: string[]) => {
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      setShowTagPopover(false);
+      return;
+    }
+    bulkApplyTags.mutate({ link_ids: selectedIds, add: toAdd, remove: toRemove });
+  };
+
+  const handleCopyUrls = () => {
+    if (!links) return;
+    const selectedLinks = links.filter((l) => selectedIds.includes(l.id));
+    const text = selectedLinks.map((l) => l.link).join("\n");
+    navigator.clipboard.writeText(text).then(() => {
+      showToast(`Copied ${selectedLinks.length} URL${selectedLinks.length !== 1 ? "s" : ""} to clipboard`);
+    });
+  };
 
   if (linkQuery.isLoading) {
     return (
@@ -145,6 +368,8 @@ const LinksContent = ({ pathId }: LinksContent) => {
           onUpdate={updatePrefs}
           linkCount={processedLinks.length}
           availableTags={availableTags}
+          selectionMode={selectionMode}
+          onToggleSelectionMode={toggleSelectionMode}
         />
       </div>
 
@@ -155,7 +380,6 @@ const LinksContent = ({ pathId }: LinksContent) => {
       )}
 
       {groupedLinks ? (
-        // Domain-grouped rendering
         <div className="w-full flex flex-col gap-6">
           {groupedLinks.map(([domain, domainLinks]) => (
             <div key={domain} className="flex flex-col gap-2">
@@ -182,18 +406,59 @@ const LinksContent = ({ pathId }: LinksContent) => {
                 gridClass={gridClass}
                 cardHeight={cardHeight}
                 showOgImage={showOgImage}
+                selectedIds={selectedIds}
+                onSelectLink={handleSelectLink}
+                selectionMode={selectionMode}
               />
             </div>
           ))}
         </div>
       ) : (
-        // Flat rendering
         <LinkGroup
           links={processedLinks}
           viewMode={prefs.viewMode}
           gridClass={gridClass}
           cardHeight={cardHeight}
           showOgImage={showOgImage}
+          selectedIds={selectedIds}
+          onSelectLink={handleSelectLink}
+          selectionMode={selectionMode}
+        />
+      )}
+
+      {/* Floating bulk action bar */}
+      {selectedIds.length > 0 && (
+        <BulkActionBar
+          selectedIds={selectedIds}
+          allLinks={links}
+          onClear={() => { dispatch(clearSelection()); setSelectionMode(false); }}
+          onDelete={handleBulkDelete}
+          onStar={() => handleBulkStar(true)}
+          onUnstar={() => handleBulkStar(false)}
+          onMove={() => setShowMoveModal(true)}
+          onTag={() => setShowTagPopover(true)}
+          onCopyUrls={handleCopyUrls}
+          isDeleting={bulkDelete.isPending}
+          isUpdating={bulkUpdate.isPending || bulkApplyTags.isPending}
+        />
+      )}
+
+      {showMoveModal && (
+        <BulkMoveModal
+          count={selectedIds.length}
+          onClose={() => setShowMoveModal(false)}
+          onMove={handleBulkMove}
+          isPending={bulkUpdate.isPending}
+        />
+      )}
+
+      {showTagPopover && (
+        <BulkTagPopover
+          selectedIds={selectedIds}
+          allLinks={links}
+          onClose={() => setShowTagPopover(false)}
+          onApplyTags={handleBulkTag}
+          isPending={bulkApplyTags.isPending}
         />
       )}
     </Fragment>

--- a/apps/web/src/store/slices/selection-slice.ts
+++ b/apps/web/src/store/slices/selection-slice.ts
@@ -1,0 +1,69 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface SelectionState {
+  selectedIds: string[];
+  anchorId: string | null;
+}
+
+const initialState: SelectionState = {
+  selectedIds: [],
+  anchorId: null,
+};
+
+const selectionSlice = createSlice({
+  name: "selection",
+  initialState,
+  reducers: {
+    toggleSelection: (state, action: PayloadAction<string>) => {
+      const id = action.payload;
+      const idx = state.selectedIds.indexOf(id);
+      if (idx === -1) {
+        state.selectedIds.push(id);
+      } else {
+        state.selectedIds.splice(idx, 1);
+      }
+      state.anchorId = id;
+    },
+    setRangeSelection: (
+      state,
+      action: PayloadAction<{ ids: string[]; anchorId: string }>,
+    ) => {
+      const { ids, anchorId } = action.payload;
+      // Merge range into existing selection without duplicates
+      const set = new Set(state.selectedIds);
+      ids.forEach((id) => set.add(id));
+      state.selectedIds = Array.from(set);
+      state.anchorId = anchorId;
+    },
+    selectAll: (state, action: PayloadAction<string[]>) => {
+      state.selectedIds = action.payload;
+      state.anchorId = null;
+    },
+    clearSelection: (state) => {
+      state.selectedIds = [];
+      state.anchorId = null;
+    },
+    removeFromSelection: (state, action: PayloadAction<string[]>) => {
+      const toRemove = new Set(action.payload);
+      state.selectedIds = state.selectedIds.filter((id) => !toRemove.has(id));
+    },
+  },
+  selectors: {
+    getSelectedIds: (state) => state.selectedIds,
+    getAnchorId: (state) => state.anchorId,
+    getSelectionCount: (state) => state.selectedIds.length,
+  },
+});
+
+export const {
+  toggleSelection,
+  setRangeSelection,
+  selectAll,
+  clearSelection,
+  removeFromSelection,
+} = selectionSlice.actions;
+
+export const { getSelectedIds, getAnchorId, getSelectionCount } =
+  selectionSlice.selectors;
+
+export default selectionSlice.reducer;

--- a/apps/web/src/store/store.ts
+++ b/apps/web/src/store/store.ts
@@ -12,10 +12,12 @@ import collectionReducer from "@store/slices/collections-slice";
 import appReducer from "@store/slices/application-slice";
 import linkReducer from "./slices/links-slice";
 import favouriteLinkReducer from "./slices/favourite-links-slice";
+import selectionReducer from "./slices/selection-slice";
+
 const persistConfig = {
   key: "onelink",
   storage,
-  blacklist: ["app"],
+  blacklist: ["app", "selection"],
 };
 
 const rootReducer = combineReducers({
@@ -24,6 +26,7 @@ const rootReducer = combineReducers({
   link: linkReducer,
   app: appReducer,
   favouriteLinks: favouriteLinkReducer,
+  selection: selectionReducer,
 });
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 


### PR DESCRIPTION
## Summary

- **Backend**: Added 3 new bulk endpoints — `POST /links/bulk-delete`, `PATCH /links/bulk`, `POST /tags/bulk` — each operating on an array of IDs in a single request
- **Frontend**: Full multi-select system — checkbox per card (hover-revealed), shift-click range, Cmd/Ctrl-click toggle, `Ctrl+A` select all, `Esc` clear, `Select` toolbar button
- **Bulk Action Bar**: Floating bottom bar appears on first selection with Star, Tag, Move, Copy URLs, and Delete actions; toast notifications on every action
- **Pickers**: `BulkMoveModal` (reuses collection tree UX) and `BulkTagPopover` (partial-state checkboxes — all/some/none semantics for mixed selections)

## What changed

### Backend
- `POST /links/bulk-delete` — delete N links, scoped to owner
- `PATCH /links/bulk` — bulk update any link fields (star, parent_id, etc.)
- `POST /tags/bulk` — add/remove named tags across N links simultaneously
- New repository methods: `bulkDeleteLinks`, `bulkUpdateLinks`, `removeTagNamesFromLink`

### Frontend
- `selection-slice.ts` — Redux slice for `selectedIds[]` + `anchorId`; blacklisted from persistence
- `useBulkDeleteLinks`, `useBulkUpdateLinks`, `useBulkApplyTags` — mutation hooks with optimistic Redux updates
- `BulkActionBar` — fixed bottom-center floating bar, visible when `selectedIds.length > 0`
- `BulkMoveModal` — adapts existing MoveToCollectionModal UX for N links
- `BulkTagPopover` — tag list with partial-state checkbox semantics
- `ToastProvider` / `useToast` — lightweight toast system added to app provider
- All 3 card variants (`LinkCard`, `LinkListItem`, `LinkCompactItem`) — `isSelected`/`onSelect` props, accent border+tint on selection, per-card hover actions hidden in selection mode

## Build status

- **Backend**: `tsc --noEmit` clean, `turbo build` passes
- **Frontend**: `tsc --noEmit` clean. Note: the Vite build fails on a pre-existing `router.tsx` type error present before this PR (confirmed via stash + build on main).

## Test plan

- [ ] Click "Select" button in toolbar — checkboxes appear on all cards
- [ ] Click a checkbox — card gets accent border, action bar appears at bottom
- [ ] Shift-click a second card — range between them is selected
- [ ] Cmd/Ctrl-click — toggles individual cards without clearing others
- [ ] `Ctrl+A` — selects all links in view
- [ ] `Esc` — clears selection and hides action bar
- [ ] Bulk star/unstar — all selected links update, toast confirms
- [ ] Bulk move — collection picker opens, selecting a destination moves all links
- [ ] Bulk tag — popover shows partial-state checkboxes for mixed tag state; apply updates all
- [ ] Bulk delete — confirmation dialog, then links removed, toast appears
- [ ] Copy URLs — clipboard gets newline-separated URLs, toast confirms count
- [ ] Works in grid, list, and compact view modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
